### PR TITLE
Switch Chrome PDF translator extension to Gemini API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,17 @@ Instagram: aaghosy
 
 
 
+
+## Chrome 扩展：PDF 选中文本翻译
+
+在 `chrome-extension/` 目录下提供了一个简单的 Chrome 扩展，用于在网页或 PDF 中选中文本后，快速翻译为中文或发送给 Gemini（需要 Gemini API Key）。
+
+### 使用方式
+1. 打开 Chrome 扩展管理页面（`chrome://extensions`），开启开发者模式。
+2. 点击“加载已解压的扩展程序”，选择本仓库中的 `chrome-extension/` 目录。
+3. 在扩展的“选项”页面中填写 Gemini API Key（可选调整模型）。
+4. 在网页里选中文本，即可弹出面板进行翻译或提问。
+
+### 注意事项
+- 由于 Chrome 内置 PDF 查看器的限制，扩展可能无法在某些内置 PDF 页面中注入脚本。对于嵌入式 PDF 或使用 pdf.js 渲染的页面效果更好。
+- 如需处理本地 PDF 文件，请在扩展详情中开启“允许访问文件网址”。

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,0 +1,88 @@
+const DEFAULT_MODEL = "gemini-1.5-flash";
+const GEMINI_ENDPOINT =
+  "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={apiKey}";
+
+async function getSettings() {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(
+      {
+        apiKey: "",
+        model: DEFAULT_MODEL,
+      },
+      (items) => resolve(items)
+    );
+  });
+}
+
+async function requestGemini({ apiKey, model, systemPrompt, userText }) {
+  const endpoint = GEMINI_ENDPOINT.replace("{model}", model).replace("{apiKey}", apiKey);
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      contents: [
+        {
+          role: "user",
+          parts: [
+            { text: systemPrompt },
+            { text: userText },
+          ],
+        },
+      ],
+      generationConfig: {
+        temperature: 0.2,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const errText = await response.text();
+    throw new Error(`Gemini API error: ${response.status} ${errText}`);
+  }
+
+  const data = await response.json();
+  const message = data.candidates?.[0]?.content?.parts
+    ?.map((part) => part.text)
+    .join("")
+    ?.trim();
+  if (!message) {
+    throw new Error("Empty response from Gemini API.");
+  }
+
+  return message;
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message?.type !== "translate" && message?.type !== "ask") {
+    return;
+  }
+
+  (async () => {
+    try {
+      const settings = await getSettings();
+      if (!settings.apiKey) {
+        throw new Error("Missing Gemini API key. Please add it in extension options.");
+      }
+
+      const systemPrompt =
+        message.type === "translate"
+          ? "Translate the following English text to Chinese. Return only the translation."
+          : "You are a helpful assistant. Answer the user's request in Chinese.";
+
+      const result = await requestGemini({
+        apiKey: settings.apiKey,
+        model: settings.model || DEFAULT_MODEL,
+        systemPrompt,
+        userText: message.text,
+      });
+
+      sendResponse({ ok: true, result });
+    } catch (error) {
+      sendResponse({ ok: false, error: error.message || String(error) });
+    }
+  })();
+
+  return true;
+});

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,0 +1,161 @@
+const panelId = "pdf-translator-panel";
+const spinnerId = "pdf-translator-spinner";
+
+function getSelectionText() {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) {
+    return "";
+  }
+  return selection.toString().trim();
+}
+
+function getSelectionRect() {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) {
+    return null;
+  }
+  const range = selection.getRangeAt(0);
+  const rect = range.getBoundingClientRect();
+  if (!rect || rect.width === 0) {
+    return null;
+  }
+  return rect;
+}
+
+function ensurePanel() {
+  let panel = document.getElementById(panelId);
+  if (panel) {
+    return panel;
+  }
+
+  panel = document.createElement("div");
+  panel.id = panelId;
+  panel.innerHTML = `
+    <div class="panel-header">
+      <span>选中文本</span>
+      <button class="panel-close" title="关闭">×</button>
+    </div>
+    <div class="panel-actions">
+      <button class="panel-btn" data-action="translate">翻译成中文</button>
+      <button class="panel-btn" data-action="ask">发给Gemini</button>
+    </div>
+    <div class="panel-body">
+      <div class="panel-placeholder">点击按钮即可显示结果</div>
+      <div class="panel-result"></div>
+      <div class="panel-error"></div>
+      <div id="${spinnerId}" class="panel-spinner" hidden>处理中...</div>
+    </div>
+  `;
+
+  document.body.appendChild(panel);
+
+  panel.querySelector(".panel-close").addEventListener("click", () => {
+    panel.classList.remove("visible");
+  });
+
+  panel.querySelectorAll(".panel-btn").forEach((button) => {
+    button.addEventListener("click", async (event) => {
+      const action = event.currentTarget.dataset.action;
+      const text = getSelectionText();
+      if (!text) {
+        showError(panel, "没有检测到选中文本。");
+        return;
+      }
+
+      await handleRequest(panel, action, text);
+    });
+  });
+
+  return panel;
+}
+
+function showPanelAt(rect) {
+  const panel = ensurePanel();
+  const top = window.scrollY + rect.bottom + 8;
+  const left = window.scrollX + rect.left;
+
+  panel.style.top = `${top}px`;
+  panel.style.left = `${left}px`;
+  panel.classList.add("visible");
+}
+
+function resetPanel(panel) {
+  const placeholder = panel.querySelector(".panel-placeholder");
+  const result = panel.querySelector(".panel-result");
+  const error = panel.querySelector(".panel-error");
+  const spinner = panel.querySelector(`#${spinnerId}`);
+
+  placeholder.style.display = "block";
+  result.textContent = "";
+  error.textContent = "";
+  spinner.hidden = true;
+}
+
+function showLoading(panel, isLoading) {
+  const spinner = panel.querySelector(`#${spinnerId}`);
+  spinner.hidden = !isLoading;
+}
+
+function showResult(panel, text) {
+  const placeholder = panel.querySelector(".panel-placeholder");
+  const result = panel.querySelector(".panel-result");
+  const error = panel.querySelector(".panel-error");
+
+  placeholder.style.display = "none";
+  result.textContent = text;
+  error.textContent = "";
+}
+
+function showError(panel, message) {
+  const placeholder = panel.querySelector(".panel-placeholder");
+  const result = panel.querySelector(".panel-result");
+  const error = panel.querySelector(".panel-error");
+
+  placeholder.style.display = "none";
+  result.textContent = "";
+  error.textContent = message;
+}
+
+async function handleRequest(panel, type, text) {
+  resetPanel(panel);
+  showLoading(panel, true);
+
+  chrome.runtime.sendMessage({ type, text }, (response) => {
+    showLoading(panel, false);
+    if (!response) {
+      showError(panel, "未收到扩展响应。");
+      return;
+    }
+    if (!response.ok) {
+      showError(panel, response.error || "请求失败。");
+      return;
+    }
+    showResult(panel, response.result);
+  });
+}
+
+function handleSelection() {
+  const text = getSelectionText();
+  if (!text) {
+    return;
+  }
+
+  const rect = getSelectionRect();
+  if (!rect) {
+    return;
+  }
+
+  const panel = ensurePanel();
+  resetPanel(panel);
+  showPanelAt(rect);
+}
+
+window.addEventListener("mouseup", () => {
+  setTimeout(handleSelection, 10);
+});
+
+window.addEventListener("keyup", (event) => {
+  if (event.key === "Shift" || event.key === "Control") {
+    setTimeout(handleSelection, 10);
+  }
+});

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "PDF Selection Translator",
+  "version": "0.1.0",
+  "description": "Translate selected English text to Chinese or send it to Gemini.",
+  "permissions": ["storage", "activeTab", "scripting"],
+  "host_permissions": ["https://generativelanguage.googleapis.com/*"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "options_page": "options.html",
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "css": ["styles.css"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/chrome-extension/options.html
+++ b/chrome-extension/options.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PDF Translator 设置（Gemini）</title>
+    <style>
+      body {
+        font-family: "Segoe UI", "PingFang SC", "Microsoft Yahei", sans-serif;
+        padding: 24px;
+        max-width: 720px;
+        margin: 0 auto;
+        color: #0f172a;
+      }
+      h1 {
+        font-size: 20px;
+        margin-bottom: 12px;
+      }
+      label {
+        display: block;
+        margin-top: 16px;
+        font-weight: 600;
+      }
+      input {
+        width: 100%;
+        margin-top: 8px;
+        padding: 10px 12px;
+        border: 1px solid #cbd5f5;
+        border-radius: 8px;
+      }
+      .hint {
+        margin-top: 6px;
+        color: #64748b;
+        font-size: 12px;
+      }
+      button {
+        margin-top: 20px;
+        padding: 10px 16px;
+        border: none;
+        background: #1d4ed8;
+        color: #ffffff;
+        border-radius: 8px;
+        cursor: pointer;
+      }
+      .status {
+        margin-top: 12px;
+        color: #0f766e;
+        font-size: 13px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>PDF Translator 设置</h1>
+    <p>请填写 Gemini API Key，选中文本后即可翻译或直接提问。</p>
+
+    <label for="apiKey">Gemini API Key</label>
+    <input id="apiKey" type="password" placeholder="AIza..." />
+    <div class="hint">Key 会保存在 Chrome 同步存储中。</div>
+
+    <label for="model">模型名称</label>
+    <input id="model" type="text" placeholder="gemini-1.5-flash" />
+    <div class="hint">默认使用 gemini-1.5-flash。</div>
+
+    <button id="save">保存设置</button>
+    <div class="status" id="status"></div>
+
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/chrome-extension/options.js
+++ b/chrome-extension/options.js
@@ -1,0 +1,29 @@
+const apiKeyInput = document.getElementById("apiKey");
+const modelInput = document.getElementById("model");
+const statusEl = document.getElementById("status");
+const saveButton = document.getElementById("save");
+
+function showStatus(message) {
+  statusEl.textContent = message;
+  setTimeout(() => {
+    statusEl.textContent = "";
+  }, 2000);
+}
+
+function loadSettings() {
+  chrome.storage.sync.get({ apiKey: "", model: "gemini-1.5-flash" }, (items) => {
+    apiKeyInput.value = items.apiKey || "";
+    modelInput.value = items.model || "gemini-1.5-flash";
+  });
+}
+
+saveButton.addEventListener("click", () => {
+  const apiKey = apiKeyInput.value.trim();
+  const model = modelInput.value.trim() || "gemini-1.5-flash";
+
+  chrome.storage.sync.set({ apiKey, model }, () => {
+    showStatus("已保存。");
+  });
+});
+
+loadSettings();

--- a/chrome-extension/styles.css
+++ b/chrome-extension/styles.css
@@ -1,0 +1,79 @@
+#pdf-translator-panel {
+  position: absolute;
+  z-index: 2147483647;
+  width: 320px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
+  border-radius: 12px;
+  font-family: "Segoe UI", "PingFang SC", "Microsoft Yahei", sans-serif;
+  color: #0f172a;
+  display: none;
+}
+
+#pdf-translator-panel.visible {
+  display: block;
+}
+
+#pdf-translator-panel .panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 12px;
+  border-bottom: 1px solid #e2e8f0;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+#pdf-translator-panel .panel-close {
+  border: none;
+  background: transparent;
+  font-size: 18px;
+  cursor: pointer;
+  color: #475569;
+}
+
+#pdf-translator-panel .panel-actions {
+  display: flex;
+  gap: 8px;
+  padding: 10px 12px;
+}
+
+#pdf-translator-panel .panel-btn {
+  flex: 1;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 13px;
+  cursor: pointer;
+  background: #1d4ed8;
+  color: #ffffff;
+}
+
+#pdf-translator-panel .panel-btn[data-action="ask"] {
+  background: #0f766e;
+}
+
+#pdf-translator-panel .panel-body {
+  padding: 10px 12px 12px;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+#pdf-translator-panel .panel-placeholder {
+  color: #64748b;
+}
+
+#pdf-translator-panel .panel-result {
+  white-space: pre-wrap;
+}
+
+#pdf-translator-panel .panel-error {
+  color: #b91c1c;
+}
+
+#pdf-translator-panel .panel-spinner {
+  margin-top: 8px;
+  font-size: 12px;
+  color: #475569;
+}


### PR DESCRIPTION
### Motivation
- Replace the extension backend and UX from OpenAI/ChatGPT to Google Gemini so the tool only uses Gemini for translations and assistant queries.

### Description
- Update `manifest.json` to reference the `generativelanguage.googleapis.com` host and change the extension description to mention Gemini. 
- Add `requestGemini` and related logic in `chrome-extension/background.js`, replace OpenAI request/response handling with Gemini-compatible payloads/parsing, and update error messages. 
- Update the selection UI in `chrome-extension/content.js` to label the action `发给Gemini` and keep the same panel/interaction flow, and update `chrome-extension/options.html` and `chrome-extension/options.js` to default to `gemini-1.5-flash` and use a Gemini API key placeholder. 
- Refresh `README.md` to document Gemini API usage and include the existing `chrome-extension/styles.css` for the floating panel styling. 

### Testing
- No automated unit tests were run for this change. 
- A Playwright attempt to render and screenshot the `options.html` page was executed but failed due to local file-loading errors (`ERR_FILE_NOT_FOUND` / `FileNotFoundError`), so no browser screenshot or live UI test was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976e675e77083299a700145a2fb1247)