### PR TITLE
Add practical ecommerce operations data-audit portfolio (schema, seed data, checks, runner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ Instagram: aaghosy
 
 
 
+
+## Portfolio Project: Ecommerce Data Audit (No Dashboards)
+I added a practical portfolio project focused on reconciliation, landed COGS accuracy, data validation, and audit trail:
+- `portfolio/ecom_data_audit/README.md`

--- a/portfolio/ecom_data_audit/README.md
+++ b/portfolio/ecom_data_audit/README.md
@@ -1,0 +1,82 @@
+# Ecommerce Data Audit Portfolio Project (Shopify + Amazon)
+
+This project demonstrates practical data controls for a DTC ecommerce brand that manufactures in China and fulfills in the US/China.
+
+## What this project proves
+- Reconcile purchased, received, in-stock, and sold units.
+- Compute landed COGS at SKU level with traceable source components.
+- Detect plausible but wrong data before decisions are made.
+- Verify outputs directly against source loads.
+- Trace every key metric to source batch, SQL logic, and run metadata.
+
+## Folder Structure
+```text
+portfolio/ecom_data_audit/
+  README.md
+  schema/
+    01_postgres_schema.sql
+  data/
+    02_seed_sample_data.sql
+  sql_checks/
+    03_control_checks.sql
+  python/
+    run_validations.py
+    requirements.txt
+  reports/
+    exception_report_design.md
+  docs/
+    case_study.md
+    application_answer.md
+```
+
+## Step-by-step build
+
+### 1) Create schema
+Run:
+```bash
+psql "$DATABASE_URL" -f portfolio/ecom_data_audit/schema/01_postgres_schema.sql
+```
+
+### 2) Load sample data (with intentional issues)
+Run:
+```bash
+psql "$DATABASE_URL" -f portfolio/ecom_data_audit/data/02_seed_sample_data.sql
+```
+
+Intentional issues include:
+- Received quantity > ordered quantity.
+- Negative duty landed-cost component.
+- Shipped quantity > ordered quantity.
+- Negative running stock in FBA due to missing inbound/transfer record.
+
+### 3) Run SQL controls
+Run:
+```bash
+psql "$DATABASE_URL" -f portfolio/ecom_data_audit/sql_checks/03_control_checks.sql
+```
+
+### 4) Run Python exception export
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r portfolio/ecom_data_audit/python/requirements.txt
+python portfolio/ecom_data_audit/python/run_validations.py --dsn "$DATABASE_URL"
+```
+
+Outputs:
+- `reports/out/<run_id>_*.csv` per control check.
+- `reports/out/<run_id>_summary.json` with run-level counts.
+
+## Core controls implemented
+1. **PO vs receipt reconciliation** (unit integrity).
+2. **Sales order quantity integrity** (`shipped <= ordered`, `returned <= shipped`).
+3. **Landed cost sanity checks** (no negative/zero critical costs).
+4. **Running inventory non-negative check** by SKU + warehouse.
+5. **Reference lineage check** (movement refs must exist).
+6. **Landed unit cost recomputation** from EXW + allocated components.
+
+## Why this matters for business impact
+- Prevents margin distortion from bad landed cost components.
+- Prevents false in-stock positions that cause overselling.
+- Prevents finance close surprises caused by inventory/sales mismatch.
+- Creates auditable history for month-end and channel settlement disputes.

--- a/portfolio/ecom_data_audit/data/02_seed_sample_data.sql
+++ b/portfolio/ecom_data_audit/data/02_seed_sample_data.sql
@@ -1,0 +1,68 @@
+SET search_path TO ecom_audit;
+
+-- Source batches
+INSERT INTO source_batch (batch_id, source_system, extract_started_at, extract_finished_at, source_file_name, source_file_sha256, row_count, loaded_by)
+VALUES
+(1001, 'ERP',          '2026-03-01 00:00+00', '2026-03-01 00:10+00', 'po_export_20260301.csv',       'sha256_po_1001', 20, 'pipeline'),
+(1002, 'WMS_CSV',      '2026-03-10 00:00+00', '2026-03-10 00:08+00', 'receipts_20260310.csv',        'sha256_rcv_1002', 30, 'pipeline'),
+(1003, 'SHOPIFY_API',  '2026-03-15 00:00+00', '2026-03-15 00:05+00', 'shopify_orders_20260315.json', 'sha256_shp_1003', 40, 'pipeline'),
+(1004, 'AMAZON_SP_API','2026-03-15 00:00+00', '2026-03-15 00:05+00', 'amazon_orders_20260315.json',  'sha256_amz_1004', 25, 'pipeline'),
+(1005, 'LANDCOST',     '2026-03-16 00:00+00', '2026-03-16 00:03+00', 'landed_cost_20260316.csv',     'sha256_lc_1005', 12, 'pipeline');
+
+INSERT INTO channel (channel_id, channel_code, channel_name) VALUES
+(1, 'SHOPIFY', 'Shopify DTC'),
+(2, 'AMAZON_US', 'Amazon US');
+
+INSERT INTO warehouse (warehouse_id, warehouse_code, warehouse_name, country_code) VALUES
+(1, 'US_3PL', 'US Third-Party Logistics', 'US'),
+(2, 'CN_FG', 'China Finished Goods Warehouse', 'CN'),
+(3, 'AMZ_FBA_US', 'Amazon FBA US', 'US');
+
+INSERT INTO sku (sku_id, sku_code, product_name) VALUES
+(101, 'SKU-A', 'Core Product A'),
+(102, 'SKU-B', 'Core Product B'),
+(103, 'SKU-C', 'Accessory C');
+
+INSERT INTO purchase_order (po_id, po_number, supplier_name, order_date, currency_code, status, batch_id) VALUES
+(5001, 'PO-2026-001', 'Shenzhen Alpha Factory', '2026-02-20', 'USD', 'PARTIAL', 1001),
+(5002, 'PO-2026-002', 'Shenzhen Alpha Factory', '2026-02-25', 'USD', 'OPEN', 1001);
+
+INSERT INTO purchase_order_line (po_line_id, po_id, sku_id, ordered_qty, unit_cost_exw) VALUES
+(6001, 5001, 101, 1000, 8.50),
+(6002, 5001, 102,  500, 6.20),
+(6003, 5002, 103,  300, 2.80);
+
+INSERT INTO inbound_shipment (inbound_id, po_id, inbound_ref, eta_date, receipt_date, destination_warehouse_id, status, batch_id) VALUES
+(7001, 5001, 'INB-PO2026001-A', '2026-03-08', '2026-03-10', 1, 'RECEIVED', 1002),
+(7002, 5002, 'INB-PO2026002-A', '2026-03-20', NULL,         1, 'IN_TRANSIT', 1002);
+
+INSERT INTO receipt_line (receipt_line_id, inbound_id, sku_id, received_qty, damaged_qty, received_at, batch_id) VALUES
+(8001, 7001, 101, 980, 5, '2026-03-10 10:00+00', 1002),
+(8002, 7001, 102, 520, 0, '2026-03-10 10:00+00', 1002);  -- Intentional issue: received > ordered for SKU-B
+
+INSERT INTO landed_cost_component (landed_component_id, inbound_id, sku_id, component_type, amount_usd, allocation_basis, batch_id) VALUES
+(9001, 7001, 101, 'FREIGHT',   1500.00, 'UNITS', 1005),
+(9002, 7001, 101, 'DUTY',       900.00, 'FOB_VALUE', 1005),
+(9003, 7001, 102, 'FREIGHT',    850.00, 'UNITS', 1005),
+(9004, 7001, 102, 'BROKER',      90.00, 'UNITS', 1005),
+(9005, 7001, 102, 'DUTY',      -120.00, 'FOB_VALUE', 1005); -- Intentional issue: negative duty
+
+INSERT INTO sales_order (sales_order_id, channel_id, external_order_id, order_created_at, order_status, ship_country_code, batch_id) VALUES
+(10001, 1, 'SH-1001', '2026-03-12 14:00+00', 'SHIPPED', 'US', 1003),
+(10002, 1, 'SH-1002', '2026-03-12 15:00+00', 'SHIPPED', 'US', 1003),
+(10003, 2, 'AMZ-9001', '2026-03-12 16:00+00', 'SHIPPED', 'US', 1004);
+
+INSERT INTO sales_order_line (sales_order_line_id, sales_order_id, sku_id, ordered_qty, shipped_qty, returned_qty, unit_price_usd, batch_id) VALUES
+(11001, 10001, 101, 2, 2, 0, 24.99, 1003),
+(11002, 10002, 102, 1, 1, 0, 19.99, 1003),
+(11003, 10003, 101, 30, 30, 0, 21.49, 1004),
+(11004, 10003, 103, 10, 12, 0, 9.99, 1004); -- Intentional issue: shipped > ordered
+
+INSERT INTO inventory_movement (movement_id, movement_ts, sku_id, warehouse_id, movement_type, qty_delta, ref_type, ref_id, batch_id) VALUES
+(12001, '2026-03-10 10:00+00', 101, 1, 'RECEIPT',      980, 'RECEIPT_LINE', '8001', 1002),
+(12002, '2026-03-10 10:00+00', 102, 1, 'RECEIPT',      520, 'RECEIPT_LINE', '8002', 1002),
+(12003, '2026-03-12 14:05+00', 101, 1, 'SALE',          -2, 'ORDER_LINE',   '11001', 1003),
+(12004, '2026-03-12 15:05+00', 102, 1, 'SALE',          -1, 'ORDER_LINE',   '11002', 1003),
+(12005, '2026-03-12 16:10+00', 101, 3, 'SALE',         -30, 'ORDER_LINE',   '11003', 1004), -- sold from FBA warehouse
+(12006, '2026-03-12 16:11+00', 103, 3, 'SALE',         -12, 'ORDER_LINE',   '11004', 1004), -- no prior receipt in FBA
+(12007, '2026-03-13 09:00+00', 101, 1, 'ADJUSTMENT',    -5, 'WMS_ADJ',      'ADJ-77', 1002);

--- a/portfolio/ecom_data_audit/docs/application_answer.md
+++ b/portfolio/ecom_data_audit/docs/application_answer.md
@@ -1,0 +1,24 @@
+# Application Answer: "Tell me about a data error others missed"
+
+I found a landed-cost error that looked plausible enough to pass casual review but materially mis-stated margin.
+
+We had a shipment where duty for one SKU was posted as a negative value due to an ingestion mapping issue. It didn't trigger a hard failure because the row was numeric and the total shipment cost still looked "in range" at a glance.
+
+I caught it by adding a control that recomputed landed unit cost from:
+1) purchase unit cost (EXW),
+2) net received quantity, and
+3) allocated freight/duty/broker components.
+
+Then I compared the output to component-level sanity rules (no negative duty/freight, no zero core costs unless explicitly exempted).
+
+Impact:
+- Gross margin was overstated for that SKU.
+- Reorder decisions would have been biased because the SKU looked more profitable than it actually was.
+
+What I changed:
+- Added automated landed-cost validation checks in SQL.
+- Added exception exports with source keys and batch lineage.
+- Required P1/P2 exceptions to be resolved before final daily finance outputs.
+
+Result:
+The team moved from "numbers look close" to auditable, reproducible controls where every metric can be traced back to source records.

--- a/portfolio/ecom_data_audit/docs/case_study.md
+++ b/portfolio/ecom_data_audit/docs/case_study.md
@@ -1,0 +1,40 @@
+# Case Study: Trustworthy Ecommerce Ops Data Without Dashboards
+
+## Context
+A fast-scaling DTC brand sells on Shopify and Amazon, manufactures in China, and fulfills in US 3PL + Amazon FBA. Teams reported "reasonable" metrics, but finance and ops repeatedly disagreed on available inventory and true COGS.
+
+## Goal
+Build a control-first data layer that answers one question reliably:
+**Can we trust unit counts and landed COGS enough to make purchasing and margin decisions?**
+
+## Approach
+1. Normalize source feeds from ERP, WMS, Shopify, and Amazon into PostgreSQL.
+2. Keep source-batch metadata for every load (`source_batch`, file hash, timestamps).
+3. Track inventory as an event ledger, not overwritten snapshots.
+4. Recompute controls directly in SQL using deterministic checks.
+5. Export actionable exceptions with ownership, severity, and lineage references.
+
+## What was validated
+- Ordered vs received by PO/SKU.
+- Received vs on-hand movement trail.
+- Sold units vs inventory decrements.
+- Landed cost components and recomputed landed unit cost.
+- Integrity of references (e.g., every sale movement has a valid order line).
+
+## Key findings from sample run
+- PO line over-receipt on SKU-B indicates receiving or PO error.
+- Amazon order line shipped quantity exceeds ordered quantity.
+- Negative duty line distorts landed COGS downward.
+- FBA inventory drops below zero because a transfer/receipt record is missing.
+
+## Business impact if unchecked
+- Overstated gross margin from understated landed cost.
+- False confidence in stock availability and replenishment timing.
+- Disputes between operations and finance during close.
+- Increased marketplace penalties from fulfillment errors.
+
+## Deliverables
+- PostgreSQL schema for traceable operations model.
+- Seed data with realistic failure modes.
+- SQL control suite + Python exception runner.
+- Exception report design for cross-functional action.

--- a/portfolio/ecom_data_audit/python/requirements.txt
+++ b/portfolio/ecom_data_audit/python/requirements.txt
@@ -1,0 +1,1 @@
+psycopg[binary]==3.2.9

--- a/portfolio/ecom_data_audit/python/run_validations.py
+++ b/portfolio/ecom_data_audit/python/run_validations.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Run SQL control checks and export exception outputs with run metadata.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+
+import psycopg
+
+CHECKS: Dict[str, str] = {
+    "po_ordered_vs_received": """
+        WITH ordered AS (
+            SELECT pol.po_id, pol.sku_id, SUM(pol.ordered_qty) AS ordered_qty
+            FROM ecom_audit.purchase_order_line pol
+            GROUP BY 1,2
+        ), received AS (
+            SELECT i.po_id, r.sku_id, SUM(r.received_qty) AS received_qty
+            FROM ecom_audit.receipt_line r
+            JOIN ecom_audit.inbound_shipment i ON i.inbound_id = r.inbound_id
+            GROUP BY 1,2
+        )
+        SELECT o.po_id, o.sku_id, o.ordered_qty, COALESCE(r.received_qty,0) AS received_qty,
+               COALESCE(r.received_qty,0) - o.ordered_qty AS qty_variance
+        FROM ordered o
+        LEFT JOIN received r ON r.po_id = o.po_id AND r.sku_id = o.sku_id
+        WHERE ABS(COALESCE(r.received_qty,0) - o.ordered_qty) > 0
+        ORDER BY 1,2
+    """,
+    "sales_quantity_integrity": """
+        SELECT sol.sales_order_line_id, so.external_order_id, s.sku_code, sol.ordered_qty, sol.shipped_qty, sol.returned_qty
+        FROM ecom_audit.sales_order_line sol
+        JOIN ecom_audit.sales_order so ON so.sales_order_id = sol.sales_order_id
+        JOIN ecom_audit.sku s ON s.sku_id = sol.sku_id
+        WHERE sol.shipped_qty > sol.ordered_qty OR sol.returned_qty > sol.shipped_qty
+        ORDER BY sol.sales_order_line_id
+    """,
+    "negative_or_zero_landed_components": """
+        SELECT l.landed_component_id, i.inbound_ref, s.sku_code, l.component_type, l.amount_usd
+        FROM ecom_audit.landed_cost_component l
+        JOIN ecom_audit.inbound_shipment i ON i.inbound_id = l.inbound_id
+        JOIN ecom_audit.sku s ON s.sku_id = l.sku_id
+        WHERE l.amount_usd < 0
+           OR (l.component_type IN ('FREIGHT','DUTY','BROKER','INSURANCE') AND l.amount_usd = 0)
+        ORDER BY l.landed_component_id
+    """,
+    "negative_running_inventory": """
+        WITH running AS (
+            SELECT movement_id, sku_id, warehouse_id, movement_ts, qty_delta,
+                   SUM(qty_delta) OVER (
+                     PARTITION BY sku_id, warehouse_id
+                     ORDER BY movement_ts, movement_id
+                   ) AS running_qty
+            FROM ecom_audit.inventory_movement
+        )
+        SELECT movement_id, sku_id, warehouse_id, movement_ts, qty_delta, running_qty
+        FROM running
+        WHERE running_qty < 0
+        ORDER BY movement_id
+    """,
+}
+
+
+def write_csv(path: Path, rows: List[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run ecommerce data audit checks")
+    parser.add_argument("--dsn", default=os.getenv("DATABASE_URL"), help="Postgres DSN or DATABASE_URL")
+    parser.add_argument("--out", default="portfolio/ecom_data_audit/reports/out", help="output directory")
+    parser.add_argument("--sql-version", default="v1.0.0")
+    parser.add_argument("--code-version", default="v1.0.0")
+    args = parser.parse_args()
+
+    if not args.dsn:
+        raise SystemExit("Missing --dsn and DATABASE_URL")
+
+    out_dir = Path(args.out)
+    run_id = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    summary = {
+        "run_id": run_id,
+        "run_started_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "sql_version": args.sql_version,
+        "code_version": args.code_version,
+        "checks": {},
+    }
+
+    with psycopg.connect(args.dsn) as conn:
+        with conn.cursor() as cur:
+            for name, sql in CHECKS.items():
+                cur.execute(sql)
+                columns = [d.name for d in cur.description]
+                rows = [dict(zip(columns, row)) for row in cur.fetchall()]
+                write_csv(out_dir / f"{run_id}_{name}.csv", rows)
+                summary["checks"][name] = {"exception_count": len(rows)}
+
+    summary["run_finished_at"] = dt.datetime.now(dt.timezone.utc).isoformat()
+    (out_dir / f"{run_id}_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/portfolio/ecom_data_audit/reports/exception_report_design.md
+++ b/portfolio/ecom_data_audit/reports/exception_report_design.md
@@ -1,0 +1,56 @@
+# Exception Report Design (Operations + Finance)
+
+## Objective
+A daily, auditable exceptions pack that operations and finance can action in under 30 minutes.
+
+## Report Sections
+1. **Run metadata**
+   - run_id
+   - run timestamp (UTC)
+   - source batch range
+   - SQL version / code version
+2. **Critical blockers (P1)**
+   - Negative inventory run-rate
+   - Broken lineage (reference missing)
+   - Shipped quantity greater than ordered
+3. **Financial risk (P2)**
+   - Negative/zero landed cost components
+   - Landed unit cost outside tolerance vs prior 30-day median
+4. **Reconciliation drift (P2/P3)**
+   - Ordered vs received variance by PO/SKU
+   - Received vs in-stock variance by SKU/warehouse
+   - Sold vs inventory decrements mismatch
+5. **Action queue**
+   - owner_team (Ops / Finance / Marketplace / Data Eng)
+   - due_by
+   - blocking_impact (stockout risk, margin overstatement, settlement mismatch)
+
+## Required Columns (per exception row)
+- exception_type
+- severity
+- business_date
+- channel_code
+- warehouse_code
+- sku_code
+- po_number / external_order_id
+- expected_value
+- actual_value
+- variance
+- source_system
+- source_batch_id
+- lineage_ref (table + primary key)
+- first_seen_at
+- last_seen_at
+- status (OPEN, ACKNOWLEDGED, RESOLVED)
+- resolution_note
+
+## Governance Rules
+- No silent overwrites: prior exception state kept in history table.
+- Every exception must link to source record keys.
+- If severity is P1, notify Slack + create ticket automatically.
+- Resolved exceptions require evidence field (e.g., corrected PO receipt in ERP).
+
+## Delivery
+- CSV extracts for ops teams.
+- JSON summary for automation.
+- Stored SQL snapshots in git for audit trail.

--- a/portfolio/ecom_data_audit/schema/01_postgres_schema.sql
+++ b/portfolio/ecom_data_audit/schema/01_postgres_schema.sql
@@ -1,0 +1,151 @@
+-- Ecommerce operations audit schema for Shopify + Amazon + 3PL + purchasing/landed cost.
+-- Focus: traceability, reconciliation, controls, and auditability.
+
+CREATE SCHEMA IF NOT EXISTS ecom_audit;
+SET search_path TO ecom_audit;
+
+-- Reference dimensions
+CREATE TABLE channel (
+    channel_id        SMALLSERIAL PRIMARY KEY,
+    channel_code      TEXT NOT NULL UNIQUE,   -- SHOPIFY, AMAZON_US, AMAZON_CA
+    channel_name      TEXT NOT NULL
+);
+
+CREATE TABLE warehouse (
+    warehouse_id      SMALLSERIAL PRIMARY KEY,
+    warehouse_code    TEXT NOT NULL UNIQUE,   -- US_3PL, CN_BOND, AMZ_FBA_US
+    warehouse_name    TEXT NOT NULL,
+    country_code      CHAR(2) NOT NULL
+);
+
+CREATE TABLE sku (
+    sku_id            SERIAL PRIMARY KEY,
+    sku_code          TEXT NOT NULL UNIQUE,
+    product_name      TEXT NOT NULL,
+    uom               TEXT NOT NULL DEFAULT 'EA',
+    active_flag       BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+-- Raw source loads with hash for immutable source trace
+CREATE TABLE source_batch (
+    batch_id          BIGSERIAL PRIMARY KEY,
+    source_system     TEXT NOT NULL,          -- SHOPIFY_API, AMAZON_SP_API, WMS_CSV, ERP
+    extract_started_at TIMESTAMPTZ NOT NULL,
+    extract_finished_at TIMESTAMPTZ NOT NULL,
+    source_file_name  TEXT,
+    source_file_sha256 TEXT,
+    row_count         INTEGER,
+    loaded_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    loaded_by         TEXT NOT NULL
+);
+
+-- Purchasing
+CREATE TABLE purchase_order (
+    po_id             BIGSERIAL PRIMARY KEY,
+    po_number         TEXT NOT NULL UNIQUE,
+    supplier_name     TEXT NOT NULL,
+    order_date        DATE NOT NULL,
+    currency_code     CHAR(3) NOT NULL,
+    status            TEXT NOT NULL,          -- OPEN, PARTIAL, RECEIVED, CLOSED
+    batch_id          BIGINT NOT NULL REFERENCES source_batch(batch_id)
+);
+
+CREATE TABLE purchase_order_line (
+    po_line_id        BIGSERIAL PRIMARY KEY,
+    po_id             BIGINT NOT NULL REFERENCES purchase_order(po_id),
+    sku_id            INTEGER NOT NULL REFERENCES sku(sku_id),
+    ordered_qty       NUMERIC(14,2) NOT NULL CHECK (ordered_qty >= 0),
+    unit_cost_exw     NUMERIC(14,4) NOT NULL CHECK (unit_cost_exw >= 0),
+    UNIQUE (po_id, sku_id)
+);
+
+CREATE TABLE inbound_shipment (
+    inbound_id        BIGSERIAL PRIMARY KEY,
+    po_id             BIGINT NOT NULL REFERENCES purchase_order(po_id),
+    inbound_ref       TEXT NOT NULL UNIQUE,
+    eta_date          DATE,
+    receipt_date      DATE,
+    destination_warehouse_id SMALLINT NOT NULL REFERENCES warehouse(warehouse_id),
+    status            TEXT NOT NULL,          -- IN_TRANSIT, RECEIVED, CLOSED
+    batch_id          BIGINT NOT NULL REFERENCES source_batch(batch_id)
+);
+
+CREATE TABLE receipt_line (
+    receipt_line_id   BIGSERIAL PRIMARY KEY,
+    inbound_id        BIGINT NOT NULL REFERENCES inbound_shipment(inbound_id),
+    sku_id            INTEGER NOT NULL REFERENCES sku(sku_id),
+    received_qty      NUMERIC(14,2) NOT NULL CHECK (received_qty >= 0),
+    damaged_qty       NUMERIC(14,2) NOT NULL DEFAULT 0 CHECK (damaged_qty >= 0),
+    received_at       TIMESTAMPTZ NOT NULL,
+    batch_id          BIGINT NOT NULL REFERENCES source_batch(batch_id)
+);
+
+-- Landed cost components allocated at inbound-shipment + sku granularity
+CREATE TABLE landed_cost_component (
+    landed_component_id BIGSERIAL PRIMARY KEY,
+    inbound_id        BIGINT NOT NULL REFERENCES inbound_shipment(inbound_id),
+    sku_id            INTEGER NOT NULL REFERENCES sku(sku_id),
+    component_type    TEXT NOT NULL,          -- FREIGHT, DUTY, BROKER, INSURANCE, OTHER
+    amount_usd        NUMERIC(14,4) NOT NULL,
+    allocation_basis  TEXT NOT NULL,          -- UNITS, WEIGHT_KG, FOB_VALUE
+    batch_id          BIGINT NOT NULL REFERENCES source_batch(batch_id)
+);
+
+-- Inventory ledger (event-sourced)
+CREATE TABLE inventory_movement (
+    movement_id       BIGSERIAL PRIMARY KEY,
+    movement_ts       TIMESTAMPTZ NOT NULL,
+    sku_id            INTEGER NOT NULL REFERENCES sku(sku_id),
+    warehouse_id      SMALLINT NOT NULL REFERENCES warehouse(warehouse_id),
+    movement_type     TEXT NOT NULL,          -- RECEIPT, SALE, ADJUSTMENT, TRANSFER_IN, TRANSFER_OUT, RETURN
+    qty_delta         NUMERIC(14,2) NOT NULL,
+    ref_type          TEXT NOT NULL,          -- RECEIPT_LINE, ORDER_LINE, WMS_ADJ, TRANSFER
+    ref_id            TEXT NOT NULL,
+    batch_id          BIGINT NOT NULL REFERENCES source_batch(batch_id)
+);
+
+-- Sales (normalized from Shopify and Amazon)
+CREATE TABLE sales_order (
+    sales_order_id    BIGSERIAL PRIMARY KEY,
+    channel_id        SMALLINT NOT NULL REFERENCES channel(channel_id),
+    external_order_id TEXT NOT NULL,
+    order_created_at  TIMESTAMPTZ NOT NULL,
+    order_status      TEXT NOT NULL,          -- OPEN, PARTIAL, SHIPPED, CANCELLED, REFUNDED
+    ship_country_code CHAR(2),
+    batch_id          BIGINT NOT NULL REFERENCES source_batch(batch_id),
+    UNIQUE (channel_id, external_order_id)
+);
+
+CREATE TABLE sales_order_line (
+    sales_order_line_id BIGSERIAL PRIMARY KEY,
+    sales_order_id    BIGINT NOT NULL REFERENCES sales_order(sales_order_id),
+    sku_id            INTEGER NOT NULL REFERENCES sku(sku_id),
+    ordered_qty       NUMERIC(14,2) NOT NULL CHECK (ordered_qty >= 0),
+    shipped_qty       NUMERIC(14,2) NOT NULL DEFAULT 0 CHECK (shipped_qty >= 0),
+    returned_qty      NUMERIC(14,2) NOT NULL DEFAULT 0 CHECK (returned_qty >= 0),
+    unit_price_usd    NUMERIC(14,4) NOT NULL,
+    batch_id          BIGINT NOT NULL REFERENCES source_batch(batch_id)
+);
+
+-- Metric lineage: each computed metric points to originating SQL + batch
+CREATE TABLE metric_run (
+    metric_run_id     BIGSERIAL PRIMARY KEY,
+    metric_name       TEXT NOT NULL,
+    run_started_at    TIMESTAMPTZ NOT NULL,
+    run_finished_at   TIMESTAMPTZ NOT NULL,
+    sql_version       TEXT NOT NULL,
+    code_version      TEXT NOT NULL,
+    input_batch_min   BIGINT NOT NULL,
+    input_batch_max   BIGINT NOT NULL,
+    row_count         INTEGER NOT NULL,
+    run_status        TEXT NOT NULL           -- SUCCESS, FAILED
+);
+
+CREATE INDEX idx_inventory_movement_sku_wh_ts
+ON inventory_movement (sku_id, warehouse_id, movement_ts);
+
+CREATE INDEX idx_sales_order_created
+ON sales_order (order_created_at);
+
+CREATE INDEX idx_receipt_line_inbound_sku
+ON receipt_line (inbound_id, sku_id);

--- a/portfolio/ecom_data_audit/sql_checks/03_control_checks.sql
+++ b/portfolio/ecom_data_audit/sql_checks/03_control_checks.sql
@@ -1,0 +1,121 @@
+SET search_path TO ecom_audit;
+
+-- 1) PO ordered vs received reconciliation by SKU
+WITH ordered AS (
+    SELECT pol.po_id, pol.sku_id, SUM(pol.ordered_qty) AS ordered_qty
+    FROM purchase_order_line pol
+    GROUP BY 1,2
+), received AS (
+    SELECT i.po_id, r.sku_id, SUM(r.received_qty) AS received_qty
+    FROM receipt_line r
+    JOIN inbound_shipment i ON i.inbound_id = r.inbound_id
+    GROUP BY 1,2
+)
+SELECT
+    o.po_id,
+    o.sku_id,
+    o.ordered_qty,
+    COALESCE(r.received_qty,0) AS received_qty,
+    COALESCE(r.received_qty,0) - o.ordered_qty AS qty_variance
+FROM ordered o
+LEFT JOIN received r
+  ON r.po_id = o.po_id AND r.sku_id = o.sku_id
+WHERE ABS(COALESCE(r.received_qty,0) - o.ordered_qty) > 0;
+
+-- 2) Invalid sales behavior: shipped > ordered, returned > shipped
+SELECT
+    sol.sales_order_line_id,
+    so.external_order_id,
+    s.sku_code,
+    sol.ordered_qty,
+    sol.shipped_qty,
+    sol.returned_qty
+FROM sales_order_line sol
+JOIN sales_order so ON so.sales_order_id = sol.sales_order_id
+JOIN sku s ON s.sku_id = sol.sku_id
+WHERE sol.shipped_qty > sol.ordered_qty
+   OR sol.returned_qty > sol.shipped_qty;
+
+-- 3) Landed cost sanity checks (negative duties/freight)
+SELECT
+    l.landed_component_id,
+    i.inbound_ref,
+    s.sku_code,
+    l.component_type,
+    l.amount_usd
+FROM landed_cost_component l
+JOIN inbound_shipment i ON i.inbound_id = l.inbound_id
+JOIN sku s ON s.sku_id = l.sku_id
+WHERE l.amount_usd < 0
+   OR (l.component_type IN ('FREIGHT', 'DUTY', 'BROKER', 'INSURANCE') AND l.amount_usd = 0);
+
+-- 4) Inventory ledger check: no movement should drive stock below zero (per SKU + warehouse)
+WITH running AS (
+    SELECT
+        movement_id,
+        sku_id,
+        warehouse_id,
+        movement_ts,
+        qty_delta,
+        SUM(qty_delta) OVER (
+            PARTITION BY sku_id, warehouse_id
+            ORDER BY movement_ts, movement_id
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS running_qty
+    FROM inventory_movement
+)
+SELECT
+    r.movement_id,
+    s.sku_code,
+    w.warehouse_code,
+    r.movement_ts,
+    r.qty_delta,
+    r.running_qty
+FROM running r
+JOIN sku s ON s.sku_id = r.sku_id
+JOIN warehouse w ON w.warehouse_id = r.warehouse_id
+WHERE r.running_qty < 0;
+
+-- 5) Traceability check: every movement ref should exist in source table where applicable
+SELECT m.movement_id, m.ref_type, m.ref_id
+FROM inventory_movement m
+LEFT JOIN receipt_line r ON m.ref_type = 'RECEIPT_LINE' AND r.receipt_line_id::TEXT = m.ref_id
+LEFT JOIN sales_order_line sol ON m.ref_type = 'ORDER_LINE' AND sol.sales_order_line_id::TEXT = m.ref_id
+WHERE (m.ref_type = 'RECEIPT_LINE' AND r.receipt_line_id IS NULL)
+   OR (m.ref_type = 'ORDER_LINE' AND sol.sales_order_line_id IS NULL);
+
+-- 6) Recompute landed unit cost and compare with expected thresholds
+WITH base AS (
+    SELECT
+        r.inbound_id,
+        r.sku_id,
+        SUM(r.received_qty - r.damaged_qty) AS net_receipt_qty
+    FROM receipt_line r
+    GROUP BY 1,2
+),
+exw AS (
+    SELECT
+        i.inbound_id,
+        pol.sku_id,
+        pol.unit_cost_exw
+    FROM inbound_shipment i
+    JOIN purchase_order_line pol ON pol.po_id = i.po_id
+),
+landed AS (
+    SELECT inbound_id, sku_id, SUM(amount_usd) AS alloc_cost
+    FROM landed_cost_component
+    GROUP BY 1,2
+)
+SELECT
+    b.inbound_id,
+    s.sku_code,
+    b.net_receipt_qty,
+    e.unit_cost_exw,
+    COALESCE(l.alloc_cost,0) AS alloc_cost,
+    ROUND(((e.unit_cost_exw * b.net_receipt_qty) + COALESCE(l.alloc_cost,0)) / NULLIF(b.net_receipt_qty,0), 4) AS landed_unit_cost
+FROM base b
+JOIN exw e ON e.inbound_id = b.inbound_id AND e.sku_id = b.sku_id
+JOIN sku s ON s.sku_id = b.sku_id
+LEFT JOIN landed l ON l.inbound_id = b.inbound_id AND l.sku_id = b.sku_id
+WHERE b.net_receipt_qty <= 0
+   OR ROUND(((e.unit_cost_exw * b.net_receipt_qty) + COALESCE(l.alloc_cost,0)) / NULLIF(b.net_receipt_qty,0), 4) <= 0;


### PR DESCRIPTION
### Motivation
- Provide a control-first portfolio project that demonstrates trustworthy numbers, reconciliation, landed COGS accuracy, inventory traceability, and audit lineage for a DTC ecommerce stack (Shopify + Amazon) with China manufacturing and US/China fulfillment.
- Emphasize detect-and-explain for plausible-but-wrong data (e.g., over-receipts, negative landed-cost lines, shipped>ordered, missing receipts) rather than dashboards.
- Showcase practical skills in PostgreSQL schema design, deterministic SQL controls, API/ETL traceability, and Python-based validation/export workflows useful for operations/finance/data-audit roles.

### Description
- Added an auditable Postgres schema at `portfolio/ecom_data_audit/schema/01_postgres_schema.sql` modeling `source_batch`, `purchase_order`/`purchase_order_line`, `inbound_shipment`/`receipt_line`, `landed_cost_component`, `inventory_movement` (event ledger), `sales_order`/`sales_order_line`, and `metric_run` for lineage.
- Added realistic seed data with intentional issues in `portfolio/ecom_data_audit/data/02_seed_sample_data.sql` to surface typical failure modes (over-receipt, negative duty, shipped>ordered, negative running inventory).
- Implemented SQL control suite in `portfolio/ecom_data_audit/sql_checks/03_control_checks.sql` covering PO vs receipt reconciliation, sales quantity integrity, landed-cost sanity, running inventory non-negative checks, reference lineage validation, and landed unit cost recomputation.
- Added a Python validation runner `portfolio/ecom_data_audit/python/run_validations.py` (and `requirements.txt`) that executes the checks via `psycopg`, writes per-check exception CSVs and a `run_id` summary JSON with run metadata and version tags, plus docs (`reports/exception_report_design.md`, `docs/case_study.md`, `docs/application_answer.md`) and a pointer in the root `README.md`.

### Testing
- Compiled the Python runner successfully with `python -m py_compile portfolio/ecom_data_audit/python/run_validations.py`, which returned `OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d22cfc1bc483299bfeb754266ed49d)